### PR TITLE
chore: point to latest snappy with correct encoding

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,8 +33,8 @@
 
     .dependencies = .{
         .snappyz = .{
-            .url = "https://github.com/blockblaz/zig-snappy/archive/dd63108.tar.gz",
-            .hash = "zig_snappy-0.0.1-bDFzXpJWAAA3c5bLc8JZK_HCwd0mGLTuFgz4LndjnVao",
+            .url = "git+https://github.com/blockblaz/zig-snappy#e87ad0795616c277c0da60ea8d8d63bbe215b841",
+            .hash = "zig_snappy-0.0.1-bDFzXvtdAAAO8v80PSHrSZauByEckEZGYjWjJL8gWlvO",
         },
     },
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -33,7 +33,7 @@
 
     .dependencies = .{
         .snappyz = .{
-            .url = "git+https://github.com/blockblaz/zig-snappy#e87ad0795616c277c0da60ea8d8d63bbe215b841",
+            .url = "https://github.com/blockblaz/zig-snappy/archive/77cb4c2a0e0c337a40454f62590459e671bc74bc.tar.gz",
             .hash = "zig_snappy-0.0.1-bDFzXvtdAAAO8v80PSHrSZauByEckEZGYjWjJL8gWlvO",
         },
     },


### PR DESCRIPTION
## Description
The crash reported in https://github.com/blockblaz/zeam/issues/465 happens due to zig-snappy's transitive dependency pointing to an old version with the bug. This PR points to updated zig-snappy with better spec alignment and coverage.