### PR TITLE
fix: accept identifier-only stream as empty payload

### DIFF
--- a/src/frames.zig
+++ b/src/frames.zig
@@ -212,7 +212,10 @@ pub fn decodeFromReader(allocator: Allocator, reader: anytype, writer: anytype) 
         chunk_buf.clearRetainingCapacity();
     }
 
-    if (!saw_data_chunk) return FrameError.NotFramed;
+    // A stream that contained the identifier but no data chunks is a valid
+    // empty payload per the Snappy framing spec. Only treat the input as
+    // unframed when neither was seen.
+    if (!saw_stream_identifier and !saw_data_chunk) return FrameError.NotFramed;
 }
 
 fn decodeFramed(allocator: Allocator, data: []const u8) ![]u8 {
@@ -273,7 +276,10 @@ fn decodeFramed(allocator: Allocator, data: []const u8) ![]u8 {
         return FrameError.UnsupportedUnskippableChunkType;
     }
 
-    if (!saw_data_chunk) return FrameError.NotFramed;
+    // A stream that contained the identifier but no data chunks is a valid
+    // empty payload per the Snappy framing spec. Only treat the input as
+    // unframed when neither was seen.
+    if (!saw_stream_identifier and !saw_data_chunk) return FrameError.NotFramed;
 
     // Some producers may omit the identifier. Only enforce when data present with mismatched chunk.
     return output.toOwnedSlice(allocator);
@@ -524,6 +530,33 @@ test "decode falls back to raw snappy payloads" {
     defer allocator.free(decoded);
 
     try std.testing.expectEqualSlices(u8, sample, decoded);
+}
+
+test "decode accepts identifier-only stream as empty payload" {
+    // A frame containing only the stream identifier (no data chunks) is a
+    // valid empty payload per the Snappy framing spec. Go's snappy.NewReader
+    // and Rust's snap::read::FrameDecoder both decode this 10-byte input to
+    // an empty slice; cross-client interop fixtures (e.g. leanSpec) emit
+    // exactly this representation for empty input.
+    const allocator = std.testing.allocator;
+    const identifier_only = "\xff\x06\x00\x00sNaPpY";
+
+    const decoded = try decode(allocator, identifier_only);
+    defer allocator.free(decoded);
+
+    try std.testing.expectEqual(@as(usize, 0), decoded.len);
+}
+
+test "decodeFromReader accepts identifier-only stream as empty payload" {
+    const allocator = std.testing.allocator;
+    const identifier_only = "\xff\x06\x00\x00sNaPpY";
+
+    var input_stream = std.io.fixedBufferStream(identifier_only);
+    var output = std.ArrayListUnmanaged(u8).empty;
+    defer output.deinit(allocator);
+
+    try decodeFromReader(allocator, input_stream.reader(), output.writer(allocator));
+    try std.testing.expectEqual(@as(usize, 0), output.items.len);
 }
 
 test "decode rejects invalid stream identifier" {


### PR DESCRIPTION
## Summary

Closes #7. \`decode\` (and \`decodeFromReader\`) rejected a 10-byte stream that contained only the magic identifier chunk and no data chunks, returning \`FrameError.NotFramed\`. The Snappy framing spec, Go's \`snappy.NewReader\`, and Rust's \`snap::read::FrameDecoder\` all accept the same input and decode it to an empty slice; cross-client interop fixtures (notably leanSpec's \`networking_codec\` suite) emit exactly this form for empty input.

## Fix

The terminal post-loop guard in both decode paths required \`saw_data_chunk\` to be set:

\`\`\`zig
if (!saw_data_chunk) return FrameError.NotFramed;
\`\`\`

Loosen it to accept any stream that has at least seen the identifier:

\`\`\`zig
if (!saw_stream_identifier and !saw_data_chunk) return FrameError.NotFramed;
\`\`\`

A stream with the identifier alone (no data chunks) is a valid empty payload and now returns an empty slice.

## Why existing tests didn't catch it

\`test \"frame roundtrip samples\"\` already round-trips \`\"\"\`, but the lib's own encoder appends an empty data chunk in \`finish()\` (\`writeEmptyChunk\`), so the encoded output never has only the identifier. The bug was decode-side only.

Two new regression tests cover the canonical 10-byte input (\`\\xff\\x06\\x00\\x00sNaPpY\`) for both \`decode\` and \`decodeFromReader\`:

\`\`\`
test "decode accepts identifier-only stream as empty payload"
test "decodeFromReader accepts identifier-only stream as empty payload"
\`\`\`

Both fail on \`main\` and pass on this branch.

## Test plan

- [x] \`zig build test --summary all\` — 13/13 tests pass (was 11/11; 2 new regression tests).
- [x] Verified with the leanSpec \`test_snappy_frame_empty\` fixture (used as the original repro in #7) — zeam's spec runner can now drop the empty-stream skip.

Discovered while implementing the leanSpec \`networking_codec\` runner in [zeam PR #715](https://github.com/blockblaz/zeam/pull/715).